### PR TITLE
Run VectorCloud in docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .directory
 vectorcloud/site.db
 *.py[cod]
+.anki_vector/
+.cache/
+.pythonpath/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,23 @@ My goal with this project is to create a web interface using Flask for controlli
 
 Please feel free to contribute.
 
+## Run in Docker
+
+One-time installation:
+```
+docker-compose \
+  -f docker-compose.yml \
+  -f docker-compose-setup.yml \
+  run --rm vectorcloud
+```
+
+Run VectorCloud:
+```
+docker-compose up vectorcloud
+```
+
+Open a browser and go to http://localhost:5000
+
 ## How to run
 * make sure git is installed on your machine
 * (recommended) create a virtual environment https://www.pythonforbeginners.com/basics/how-to-use-python-virtualenv/

--- a/docker-compose-setup.yml
+++ b/docker-compose-setup.yml
@@ -1,0 +1,4 @@
+version: "3.7"
+services:
+  vectorcloud:
+    command: pip install --target=.pythonpath -r requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.7"
+services:
+  vectorcloud:
+    image: python:3
+    volumes:
+      - .:/vectorcloud
+    working_dir: /vectorcloud
+    environment:
+      HOME: '/vectorcloud'
+      PYTHONPATH: '/vectorcloud/.pythonpath'
+    ports:
+      - 5000:5000
+    command: python3 run.py


### PR DESCRIPTION
Here's an example of how to run VectorCloud in docker.  The docker compose configurations save all the important files in folders inside the VectorCloud folder:
- `.anki_vector` is where the `sdk_config.ini` and anki certificate get saved.
- `.cache` and `.pythonpath` are where the python libraries from `requirements.txt` get installed.

There's a decent chance this will also make it easier for people to get VectorCloud running on a Raspberry Pi.